### PR TITLE
Add .travis.yml and status tag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+sudo: required
+cache: apt
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      env: CXX_COMPILER=g++-6
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - g++-6
+          - pandoc
+    - os: linux
+      dist: trusty
+      env: CXX_COMPILER=g++-7
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - g++-7
+          - pandoc
+    - os: linux
+      dist: trusty
+      compiler: clang++
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - g++-7
+          - pandoc
+    - os: osx
+      osx_image: xcode9.2
+    - os: osx
+      osx_image: xcode8.3
+
+before_install:
+  - echo "PATH = $PATH"
+  - echo "HOME = $HOME"
+  # We need to re-export CC and CXX here, because travis exports CXX=g++ or clang++ AFTER we set CXX.
+  - if [ -n "${C_COMPILER}" ]; then export CC="${C_COMPILER}"; fi
+  - if [ -n "${CXX_COMPILER}" ]; then export CXX="${CXX_COMPILER}"; fi
+
+script:
+  - PATH=$(pwd)/bin/:$PATH
+  - echo "PATH = $PATH"
+  - mkdir build
+  - cd build
+  - cmake ..
+  - make
+# Run testiphy test suite
+  - cd
+  - git clone https://gitlab.com/testiphy/testiphy.git
+  - cd testiphy
+  - which raxml-ng
+  - ./testiphy raxml-ng

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RAxML Next Generation
 
-[![DOI](https://zenodo.org/badge/75947982.svg)](https://zenodo.org/badge/latestdoi/75947982) [![License](https://img.shields.io/badge/license-AGPL-blue.svg)](http://www.gnu.org/licenses/agpl-3.0.en.html)
+[![Build Status](https://www.travis-ci.org/amkozlov/raxml-ng.svg?branch=master)](https://www.travis-ci.org/amkozlov/raxml-ng) [![DOI](https://zenodo.org/badge/75947982.svg)](https://zenodo.org/badge/latestdoi/75947982) [![License](https://img.shields.io/badge/license-AGPL-blue.svg)](http://www.gnu.org/licenses/agpl-3.0.en.html)
 
 ## Introduction
 


### PR DESCRIPTION
Hi Alexey,

Here is a travis file for raxml-ng.  It builds raxml-ng and then runs testiphy on it.  It targets Linux/gcc, Linux/clang, and OS X/clang.  Before it will actually do anything you need to get an account on travis-ci.org (not travis-ci.com) linked to your github account, and then enable the testing for the raxml-ng repo (click on your profile picture to see your repos on travis).

-BenRI