### PR TITLE
added GTEST headers as determined by FindGTest

### DIFF
--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -14,6 +14,7 @@ file (GLOB_RECURSE RAXML_TEST_SOURCES ${PROJECT_SOURCE_DIR}/test/src/*.cpp ${RAX
 list(REMOVE_ITEM RAXML_TEST_SOURCES "${PROJECT_SOURCE_DIR}/src/main.cpp")
 
 include_directories (${PROJECT_SOURCE_DIR})
+include_directories (${GTEST_INCLUDE_DIRS})
 
 set (EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/test/bin)
 


### PR DESCRIPTION
decreses reliance on setup of the PATH variables which can be a bit weird under conda