### PR TITLE
added supposedly missing header in some macos builds

### DIFF
--- a/src/util/sysutil.cpp
+++ b/src/util/sysutil.cpp
@@ -5,7 +5,9 @@
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#if defined __APPLE__
 #include <sys/sysctl.h>
+#endif
 #include <stdarg.h>
 #include <limits.h>
 

--- a/src/util/sysutil.cpp
+++ b/src/util/sysutil.cpp
@@ -5,6 +5,7 @@
 #include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysctl.h>
 #include <stdarg.h>
 #include <limits.h>
 


### PR DESCRIPTION
see for example: https://circleci.com/gh/bioconda/bioconda-recipes/97527?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link