### PR TITLE
add flag to write out bootstrap msa from main run

### DIFF
--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -165,6 +165,14 @@ void CommandLineParser::check_options(Options &opts)
         "but the current command does not perform bootstrapping.\n"
         "Did you forget --all option?");
   }
+    
+  if (opts.write_bs_msa && opts.command != Command::bsmsa &&
+      opts.command != Command::bootstrap && opts.command != Command::all)
+  {
+    throw OptionException("You specified to write out boostrap alignments with --bs-write-msa option, "
+      "but the current command does not perform bootstrapping.\n"
+      "Did you forget --all option?");
+  }
 
   if (opts.simd_arch > sysutil_simd_autodetect())
   {

--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -78,6 +78,7 @@ static struct option long_options[] =
   {"workers",            required_argument, 0, 0 },  /*  54 */
   {"sitelh",             no_argument, 0, 0 },        /*  55 */
   {"site-weights",       required_argument, 0, 0 },  /*  56 */
+  {"bs-write-msa",       no_argument, 0, 0 },        /*  57 */
 
   { 0, 0, 0, 0 }
 };
@@ -318,6 +319,7 @@ void CommandLineParser::parse_options(int argc, char** argv, Options &opts)
 
   opts.num_searches = 0;
   opts.num_bootstraps = 0;
+  opts.write_bs_msa = false;
 
   opts.force_mode = false;
   opts.safety_checks = SafetyCheck::all;
@@ -905,7 +907,10 @@ void CommandLineParser::parse_options(int argc, char** argv, Options &opts)
         opts.weights_file = optarg;
         break;
 
-
+      case 57: /* write bootstrap alignments*/
+        opts.write_bs_msa = true;
+        break;
+            
       default:
         throw  OptionException("Internal error in option parsing");
     }
@@ -1019,7 +1024,8 @@ void CommandLineParser::print_help()
             "  --bs-trees     autoMRE{N}                  use MRE-based bootstrap convergence criterion, up to N replicates (default: 1000)\n"
             "  --bs-trees     FILE                        Newick file containing set of bootstrap replicate trees (with --support)\n"
             "  --bs-cutoff    VALUE                       cutoff threshold for the MRE-based bootstopping criteria (default: 0.03)\n"
-            "  --bs-metric    fbp | tbe                   branch support metric: fbp = Felsenstein bootstrap (default), tbe = transfer distance\n";
+            "  --bs-metric    fbp | tbe                   branch support metric: fbp = Felsenstein bootstrap (default), tbe = transfer distance\n"
+            "  --bs-write-msa on | off                    write all bootstrap alignments (default: OFF)\n";
 
   cout << "\n"
             "EXAMPLES:\n"

--- a/src/Options.hpp
+++ b/src/Options.hpp
@@ -68,6 +68,7 @@ public:
   bool redo_mode;
   bool nofiles_mode;
   bool write_interim_results;
+  bool write_bs_msa;
 
   LogLevel log_level;
   FileFormat msa_format;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2339,7 +2339,7 @@ void print_final_output(const RaxmlInstance& instance, const CheckpointFile& che
     }
   }
 
-  if (opts.command == Command::bsmsa)
+  if (opts.command == Command::bsmsa || opts.write_bs_msa == true)
   {
     if (!opts.bootstrap_msa_file(1).empty())
     {
@@ -3010,6 +3010,7 @@ void master_main(RaxmlInstance& instance, CheckpointManager& cm)
         parted_msa.model(p, ml_models.at(p));
     }
   }
+
 }
 
 int clean_exit(int retval)


### PR DESCRIPTION
It would be extremely useful if raxml-ng could write out bootstrap multiple sequence alignments from tree building runs (e.g. `--all`). Although the `--bsmsa` mode allows a user to write out bootstrap alignments, doing subsequent tree building on these alignments loses the fast parallelization native to raxml-ng/libpll. I'd like to run `--all` and be able to get a stack of bootstrap trees and alignments I can then use for downstream analyses. 

I implemented a new flag (`--bs-write-msa`) that causes raxml-ng to call the code block under control of `Command::bsmsa`, thus writing out the bootstrap replicate alignments after tree creation. The new flag sets a new `write_bs_msa` boolean I added to the main opts data structure.  I added a doc string to the command line argument and an error check to make sure the flag is only invoked if bootstrap replicates are being generated. 

Not sure if there I should merge into dev or master. (It looked like dev was stale). Let me know if I should change PR branches. 

Thanks for great package and for considering PR. 