### PR TITLE
Add SPR round optimization by @togkousa

### DIFF
--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -286,6 +286,9 @@ void CommandLineParser::parse_options(int argc, char** argv, Options &opts)
   /* use new split-based constraint checking method -> slightly slower, but more reliable */
   opts.use_old_constraint = false;
 
+  /* disable incremental CLV updates across pruned subtrees in SPR rounds */
+  opts.use_spr_fastclv = false;
+
   /* optimize model and branch lengths */
   opts.optimize_model = true;
   opts.optimize_brlen = true;
@@ -812,6 +815,10 @@ void CommandLineParser::parse_options(int argc, char** argv, Options &opts)
               opts.use_old_constraint = true;
             else if (eopt == "constraint-new")
               opts.use_old_constraint = false;
+            else if (eopt == "fastclv-on")
+              opts.use_spr_fastclv = true;
+            else if (eopt == "fastclv-off")
+              opts.use_spr_fastclv = false;
             else
               throw InvalidOptionValueException("Unknown extra option: " + string(eopt));
           }

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -7,6 +7,7 @@ using namespace std;
 Options::Options() : opt_version(RAXML_OPT_VERSION), cmdline(""), command(Command::none),
 use_tip_inner(true), use_pattern_compression(true), use_prob_msa(false), use_rate_scalers(false),
 use_repeats(true), use_rba_partload(true), use_energy_monitor(true), use_old_constraint(false),
+use_spr_fastclv(false),
 optimize_model(true), optimize_brlen(true), force_mode(false), safety_checks(SafetyCheck::all),
 redo_mode(false), nofiles_mode(false), write_interim_results(true), write_bs_msa(false),
 log_level(LogLevel::progress), msa_format(FileFormat::autodetect), data_type(DataType::autodetect),
@@ -412,7 +413,8 @@ std::ostream& operator<<(std::ostream& stream, const Options& opts)
     stream << "  per-rate scalers: " << (opts.use_rate_scalers ? "ON" : "OFF") << endl;
     stream << "  site repeats: " << (opts.use_repeats ? "ON" : "OFF") << endl;
 
-    if (opts.command == Command::search)
+    if (opts.command == Command::search || opts.command == Command::all ||
+        opts.command == Command::bootstrap)
     {
       if (opts.spr_radius > 0)
         stream << "  fast spr radius: " << opts.spr_radius << endl;
@@ -423,6 +425,8 @@ std::ostream& operator<<(std::ostream& stream, const Options& opts)
         stream << "  spr subtree cutoff: " << opts.spr_cutoff << endl;
       else
         stream << "  spr subtree cutoff: OFF" << endl;
+
+      stream << "  fast CLV updates: " << (opts.use_spr_fastclv ? "ON" : "OFF") << endl;
     }
 
     stream << "  branch lengths: ";

--- a/src/Options.hpp
+++ b/src/Options.hpp
@@ -59,6 +59,7 @@ public:
   bool use_rba_partload;
   bool use_energy_monitor;
   bool use_old_constraint;
+  bool use_spr_fastclv;
 
   bool optimize_model;
   bool optimize_brlen;

--- a/src/TreeInfo.cpp
+++ b/src/TreeInfo.cpp
@@ -30,6 +30,7 @@ void TreeInfo::init(const Options &opts, const Tree& tree, const PartitionedMSA&
   _brlen_opt_method = opts.brlen_opt_method;
   _check_lh_impr = opts.safety_checks.isset(SafetyCheck::model_lh_impr);
   _use_old_constraint = opts.use_old_constraint;
+  _use_spr_fastclv = opts.use_spr_fastclv;
 
   _partition_contributions.resize(parted_msa.part_count());
   double total_weight = 0;
@@ -389,7 +390,7 @@ double TreeInfo::spr_round(spr_round_params& params)
                                _brlen_min, _brlen_max, RAXML_BRLEN_SMOOTHINGS,
                                0.1,
                                params.subtree_cutoff > 0. ? &params.cutoff_info : nullptr,
-                               params.subtree_cutoff);
+                               _use_spr_fastclv);
 
   libpll_check_error("ERROR in SPR round");
 

--- a/src/TreeInfo.cpp
+++ b/src/TreeInfo.cpp
@@ -390,6 +390,7 @@ double TreeInfo::spr_round(spr_round_params& params)
                                _brlen_min, _brlen_max, RAXML_BRLEN_SMOOTHINGS,
                                0.1,
                                params.subtree_cutoff > 0. ? &params.cutoff_info : nullptr,
+                               params.subtree_cutoff,
                                _use_spr_fastclv);
 
   libpll_check_error("ERROR in SPR round");

--- a/src/TreeInfo.hpp
+++ b/src/TreeInfo.hpp
@@ -71,6 +71,7 @@ private:
   double _brlen_max;
   bool _check_lh_impr;
   bool _use_old_constraint;
+  bool _use_spr_fastclv;
   doubleVector _partition_contributions;
 
   void init(const Options &opts, const Tree& tree, const PartitionedMSA& parted_msa,

--- a/src/version.h
+++ b/src/version.h
@@ -1,2 +1,2 @@
 #define RAXML_VERSION "1.1.0-fastclv"
-#define RAXML_DATE "21.02.2023"
+#define RAXML_DATE "28.02.2023"

--- a/src/version.h
+++ b/src/version.h
@@ -1,2 +1,2 @@
 #define RAXML_VERSION "1.1.0-fastclv"
-#define RAXML_DATE "28.02.2023"
+#define RAXML_DATE "06.03.2023"

--- a/src/version.h
+++ b/src/version.h
@@ -1,2 +1,2 @@
 #define RAXML_VERSION "1.1.0-dev"
-#define RAXML_DATE "13.02.2023"
+#define RAXML_DATE "16.02.2023"


### PR DESCRIPTION
Usage:
`--extra fastclv-on`  = optimized / incremental CLV updates
`--extra fastclv-off` = legacy mode / compatible with raxml-ng 1.1 and below (default)
