### PR TITLE
fix cmake file overriding cxx flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 message (STATUS "Building ${CMAKE_BUILD_TYPE}")
 
 set (WARN_FLAGS               "-Wall -Wextra")
-set (CMAKE_CXX_FLAGS          "-std=c++11 ${WARN_FLAGS}")
+set (CMAKE_CXX_FLAGS          "${CMAKE_CXX_FLAGS} -std=c++11 ${WARN_FLAGS}")
 
 if (ENABLE_GMP)
 #find_package(GMP REQUIRED)


### PR DESCRIPTION
The CMAKE file overrides the CMAKE_CXX_FLAGS variable preventing flags being enabled through command line