### PR TITLE
Fix `iostream_category` error when writing bootstrap MSAs

### DIFF
--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -952,6 +952,7 @@ void CommandLineParser::parse_options(int argc, char** argv, Options &opts)
 
       case 57: /* write bootstrap alignments*/
         opts.write_bs_msa = true;
+        opts.use_par_pars = false; // Disables parallel parsing so master populates instance.bs_reps
         break;
 
       case 58: /* triplet LH epsilon */


### PR DESCRIPTION
### Problem Description
When running `raxml-ng 1.2.2` with the `--bs-write-msa` flag to generate and write bootstrap replicate MSAs (using `Command::bsmsa` or `--all`), the program crashes with an `unspecified iostream_category error` (specifically `"File doesn't exist"` thrown by `sysutil_realpath`).

This occurs because of an interaction between the parallelized bootstrap generation architecture and the file writing loop. By default, `opts.use_par_pars` is enabled, which means bootstrap replicates are generated on-the-fly by worker threads. Consequently, the master thread's `instance.bs_reps` list remains empty. However, the code block in `main.cpp` that attempts to write out the MSAs iterates over `instance.bs_reps`. Since the list is empty, no MSA files are ever created. Immediately following this loop, the program attempts to log the absolute path to the first replicate file (`sysutil_realpath(opts.bootstrap_msa_file(1))`), which fails and throws the exception because the file never materialized.

### Solution
To fix this, the `--bs-write-msa` flag must explicitly disable `use_par_pars` so that the bootstrap replicates are materialized in the `instance.bs_reps` list on the master thread before they are iterated over for file writing.

**Patch applied in `src/CommandLineParser.cpp`:**
```cpp
      case 57: /* write bootstrap alignments*/
        opts.write_bs_msa = true;
        opts.use_par_pars = false; // Disables parallel parsing so master populates instance.bs_reps
        break;
```
This ensures the MSA files are correctly generated and resolves the crash.

### Reproducing the error
This error affects locally compiled versions of the current source code, as well as the binary on bioconda. This call uses this phylip alignment: [alignment.txt](https://github.com/user-attachments/files/25817733/alignment.txt). 

```
raxml-ng --msa txt --bs-write-msa --all --model LG
```

And yields.
```
...
Best ML tree saved to: /Users/harmsm/tmp/alignment.phy.raxml.bestTree
All ML trees saved to: /Users/harmsm/tmp/alignment.phy.raxml.mlTrees
Best ML tree with Felsenstein bootstrap (FBP) support values saved to: /Users/harmsm/tmp/alignment.phy.raxml.support
Optimized model saved to: /Users/harmsm/tmp/alignment.phy.raxml.bestModel
Bootstrap trees saved to: /Users/harmsm/tmp/alignment.phy.raxml.bootstraps
Bootstrap replicate MSAs saved to:
ERROR: File doesn't exist: alignment.phy.raxml.bootstrapMSA.1.phy: unspecified iostream_category error
```

