### PR TITLE
protect empty labels to avoid NULL pointer segfault

### DIFF
--- a/src/MSA.cpp
+++ b/src/MSA.cpp
@@ -344,9 +344,12 @@ void MSA::remove_taxa(const IDSet& taxon_ids)
     if (ignore == taxon_ids.cend() || i != *ignore)
     {
       new_sequences.push_back(_sequences[i]);
-      const auto label = _labels[i];
-      new_labels.push_back(label);
-      _label_id_map[label] = new_labels.size() - 1;
+      if (!_labels.empty())
+      {
+        const auto label = _labels[i];
+        new_labels.push_back(label);
+        _label_id_map[label] = new_labels.size() - 1;
+      }
     }
     else
       ignore++;


### PR DESCRIPTION
This addresses bug #232 by having a protection to check for empty value of _labels before accessing it.

Note that  update_pll_msa() 
uses
```
assert(_labels.empty() || _labels.size() == _sequences.size()) 
```
To handle the empty case, but remove_taxa() doesn't.

This bugfix was assisted by AI.