### PR TITLE
add no-inline and frame-pointers to debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,11 +42,11 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # set these flags globally for all subprojects (libpll etc.)
-set(CMAKE_CXX_FLAGS_DEBUG "-Og -ggdb -g3 -grecord-gcc-switches" CACHE INTERNAL "")
-set(CMAKE_C_FLAGS_DEBUG "-Og -ggdb -g3 -grecord-gcc-switches" CACHE INTERNAL "")
+set(CMAKE_CXX_FLAGS_DEBUG "-Og -ggdb -g3 -grecord-gcc-switches -fno-omit-frame-pointer -fno-inline" CACHE INTERNAL "")
+set(CMAKE_C_FLAGS_DEBUG "-Og -ggdb -g3 -grecord-gcc-switches -fno-omit-frame-pointer -fno-inline" CACHE INTERNAL "")
 
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -ggdb -g3 -grecord-gcc-switches" CACHE INTERNAL "")
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -ggdb -g3 -grecord-gcc-switches" CACHE INTERNAL "")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -ggdb -g3 -grecord-gcc-switches -fno-omit-frame-pointer -fno-inline" CACHE INTERNAL "")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -ggdb -g3 -grecord-gcc-switches -fno-omit-frame-pointer -fno-inline" CACHE INTERNAL "")
 
 set (CMAKE_CXX_FLAGS_RELEASE  "-O3"    CACHE INTERNAL "")
 set (CMAKE_C_FLAGS_RELEASE  "-O3"    CACHE INTERNAL "")


### PR DESCRIPTION
To fully resolve stack traces during debugging, inlining needs to be disabled completely because GDB is unable to recover the callsite of inlined code even if the callsite itself is not inlined. This will affect performance in debug builds, but `-Og` is still present.

Note: EBG and Pythia forcibly add `-O1` (so they do not inherit `-Og`) and I do not know what takes precedence, so I don't know if those modules can still be inlined.